### PR TITLE
derive(Debug) for all public types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ use windows::{PlatformData, get_resident, get_page_size, map_file, unmap_file, p
 ///
 /// It is recommended to ensure that other applications do not write to the file when it is mapped,
 /// possibly by marking the file read-only. (Though even this is no guarantee.)
+#[derive(Debug)]
 pub struct FileBuffer {
     page_size: usize,
     buffer: *const u8,

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -16,6 +16,7 @@ use std::thread;
 
 extern crate libc;
 
+#[derive(Debug)]
 pub struct PlatformData;
 
 pub fn map_file(file: fs::File) -> io::Result<(*const u8, usize, PlatformData)> {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -16,6 +16,7 @@ use std::ptr;
 extern crate kernel32;
 extern crate winapi;
 
+#[derive(Debug)]
 pub struct PlatformData {
     // On Windows, the file must be kept open for the lifetime of the mapping.
     #[allow(dead_code)] // The field is not dead, the destructor is effectful.


### PR DESCRIPTION
The rust [documentation] for `fmt::Debug` states that libraries should ensure that all public types implement the `Debug` trait:

> `fmt::Debug` implementations should be implemented for **all** public types. Output will typically represent the internal state as faithfully as possible. The purpose of the `Debug` trait is to facilitate debugging Rust code. In most cases, using `#[derive(Debug)]` is sufficient and recommended.

[documentation]: https://doc.rust-lang.org/std/fmt/#fmtdisplay-vs-fmtdebug

This PR adds the necessary code to follow this spec, allowing users of filebuffer to `#[derive(Debug)]` on their own structs that utilize filebuffer types.